### PR TITLE
DM-31848: Remove faro steps from ci_imsim_run.py.

### DIFF
--- a/bin.src/ci_imsim_run.py
+++ b/bin.src/ci_imsim_run.py
@@ -13,9 +13,6 @@ QGRAPH_FILE = "DRP.qgraph"
 INPUTCOL = f"{INSTRUMENT_NAME}/defaults"
 COLLECTION = f"{INSTRUMENT_NAME}/runs/ci_imsim"
 
-QGRAPH_FARO_FILE = "faro.qgraph"
-COLLECTION_FARO = f"{INSTRUMENT_NAME}/runs/ci_imsim/faro"
-
 index_command = 0
 
 ciRunner = CommandRunner(os.environ["CI_IMSIM_DIR"])
@@ -118,42 +115,6 @@ class ProcessingCommand(BaseCommand):
             "--register-dataset-types",
             "--skip-existing",
             "--qgraph", os.path.join(self.runner.RunDir, QGRAPH_FILE),
-        )
-        pipetask = self.runner.getExecutableCmd("CTRL_MPEXEC_DIR", "pipetask", args)
-        subprocess.run(pipetask, check=True)
-
-
-@ciRunner.register("qgraph_faro", index_command := index_command + 1)
-class QgraphFaroCommand(BaseCommand):
-    def run(self, currentState: BuildState):
-        args = (
-            "--long-log",
-            "qgraph",
-            "-d", "skymap='discrete/ci_imsim/4k' AND tract=0 AND patch=24",
-            "-b", self.runner.RunDir,
-            "--input", COLLECTION,
-            "--output", COLLECTION_FARO,
-            "-p", os.path.join(os.environ["FARO_DIR"], "pipelines", "metrics_pipeline.yaml"),
-            "--skip-existing",
-            "--save-qgraph", os.path.join(self.runner.RunDir, QGRAPH_FARO_FILE),
-        )
-        pipetask = self.runner.getExecutableCmd("CTRL_MPEXEC_DIR", "pipetask", args)
-        subprocess.run(pipetask, check=True)
-
-
-@ciRunner.register("process_faro", index_command := index_command + 1)
-class ProcessingFaroCommand(BaseCommand):
-    def run(self, currentState: BuildState):
-        args = (
-            "--long-log",
-            "run",
-            "-j", str(self.arguments.num_cores),
-            "-b", self.runner.RunDir,
-            "--input", COLLECTION,
-            "--output", COLLECTION_FARO,
-            "--register-dataset-types",
-            "--skip-existing",
-            "--qgraph", os.path.join(self.runner.RunDir, QGRAPH_FARO_FILE),
         )
         pipetask = self.runner.getExecutableCmd("CTRL_MPEXEC_DIR", "pipetask", args)
         subprocess.run(pipetask, check=True)


### PR DESCRIPTION
Because the `faro` steps are now in `obs_lsst/pipelines/imsim/DRP.yaml`, they don't need to be pulled directly into `ci_imsim`.