### PR TITLE
tickets/DM-33992 Constrain graph only on raws

### DIFF
--- a/bin.src/ci_imsim_run.py
+++ b/bin.src/ci_imsim_run.py
@@ -92,6 +92,7 @@ class QgraphCommand(BaseCommand):
             "--output", COLLECTION,
             "-p", "$DRP_PIPE_DIR/pipelines/LSSTCam-imSim/DRP-ci_imsim.yaml",
             "--skip-existing",
+            "--dataset-query-constraint", "raw",  # workaround pending DM-34247
             "--save-qgraph", os.path.join(self.runner.RunDir, QGRAPH_FILE),
             "--config", f"deblend:multibandDeblend.useCiLimits={self.arguments.limit_deblend}",
             "--config", f"calibrate:deblend.useCiLimits={self.arguments.limit_deblend}",


### PR DESCRIPTION
Until DM-34247 is finished it is impossible to construct graphcs
with overall inputs that have nod dimensions. Only explicitly
constrain graph creation on raw dataset types, which is perfectly
fine for this dataset.