### PR TITLE
DM-34247: Revert "Constrain graph only on raws"

### DIFF
--- a/bin.src/ci_imsim_run.py
+++ b/bin.src/ci_imsim_run.py
@@ -92,7 +92,6 @@ class QgraphCommand(BaseCommand):
             "--output", COLLECTION,
             "-p", "$DRP_PIPE_DIR/pipelines/LSSTCam-imSim/DRP-ci_imsim.yaml",
             "--skip-existing",
-            "--dataset-query-constraint", "raw",  # workaround pending DM-34247
             "--save-qgraph", os.path.join(self.runner.RunDir, QGRAPH_FILE),
             "--config", f"deblend:multibandDeblend.useCiLimits={self.arguments.limit_deblend}",
             "--config", f"calibrate:deblend.useCiLimits={self.arguments.limit_deblend}",


### PR DESCRIPTION
This reverts commit 49c92a880571f46c757ab8732892bb960be8468b; the bug that required it was fixed upstream in daf_butler on DM-34247. (lsst/daf_butler#670)