### PR TITLE
DM-34466-v23:  compare calibratedSourceTable_visit to source schema

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -70,7 +70,7 @@ class TestSchemaMatch(lsst.utils.tests.TestCase):
     def testSourceSchemaMatch(self):
         """Check one sourceTable_visit"""
         dataId = {"instrument": "LSSTCam-imSim", "detector": 100, "visit": 5884, "band": "y"}
-        self._validateSchema("sourceTable_visit", dataId, "source")
+        self._validateSchema("calibratedSourceTable_visit", dataId, "source")
 
     def testForcedSourceSchemaMatch(self):
         """Check forcedSourceTable_tract"""


### PR DESCRIPTION
The parquet source tables in 23.0.0 use the wrong photometric
and astrometric calibrations. A subsequent task regeneterates them with the
best calibs and this data product,  calibratedSourceTable_visit, is
the best source table to be ingested.