### PR TITLE
DM-38210: Use Butler.get instead of deprecated getDirect

### DIFF
--- a/tests/test_hips_outputs.py
+++ b/tests/test_hips_outputs.py
@@ -51,7 +51,7 @@ class TestHipsOutputs(unittest.TestCase):
             for dataset in datasets:
                 self.assertTrue(self.butler.datastore.exists(dataset), msg="File exists for deepCoadd_hpx")
 
-            exp = self.butler.getDirect(list(datasets)[0])
+            exp = self.butler.get(list(datasets)[0])
 
             self.assertEqual(exp.wcs.getFitsMetadata()["CTYPE1"], "RA---HPX")
             self.assertEqual(exp.wcs.getFitsMetadata()["CTYPE2"], "DEC--HPX")


### PR DESCRIPTION
Depends on lsst/daf_butler#797