### PR TITLE
DM-39031: Specify output collection for graph building script

### DIFF
--- a/bin.src/ci_imsim_run.py
+++ b/bin.src/ci_imsim_run.py
@@ -135,6 +135,7 @@ class HipsQgraphCommand(BaseCommand):
             "-b", self.runner.RunDir,
             "-p", "$CI_IMSIM_DIR/resources/highres_hips.yaml",
             "-i", COLLECTION,
+            "--output", HIPS_COLLECTION,
             "--pixels", str(33),
             "-q", os.path.join(self.runner.RunDir, HIPS_QGRAPH_FILE)
         )


### PR DESCRIPTION
The special graph building script for HiPS task now requires an output collection name to resolve output references.